### PR TITLE
🩹 Fix nullable state property

### DIFF
--- a/src/Concerns/HasEditRecordModal.php
+++ b/src/Concerns/HasEditRecordModal.php
@@ -8,7 +8,7 @@ trait HasEditRecordModal
 {
     public bool $disableEditModal = false;
 
-    public array $editModalFormState = [];
+    public ?array $editModalFormState = [];
 
     public ?int $editModalRecordId = null;
 


### PR DESCRIPTION
I ran into an issue where Filament was setting the state to `null` causing the `$editModalFormState` property to throw an error while editing. This seems to fix it with no side-effects and everything works as intended.

![Screenshot](https://i.imgur.com/LMuCk9m.png)

![Screenshot](https://i.imgur.com/qP5DZ5k.png)