### PR TITLE
🩹 Fix sorting when using SPA mode

### DIFF
--- a/resources/views/kanban-scripts.blade.php
+++ b/resources/views/kanban-scripts.blade.php
@@ -20,7 +20,7 @@
         Livewire.dispatch('sort-changed', {recordId, status, orderedIds})
     }
 
-    window.onload = () => {
+    document.addEventListener('livewire:navigated', () => {
         @foreach($statuses as $status)
             {{-- dont touch this line --}}
             Sortable.create(document.getElementById('{{ $status['id'] }}'), {
@@ -34,5 +34,5 @@
                 onAdd,
             })
         @endforeach
-    }
+    })
 </script>


### PR DESCRIPTION
This fixes sorting when navigating between pages using Filament's [SPA mode](https://filamentphp.com/docs/3.x/panels/configuration#spa-mode). Still works as intended without.