### PR TITLE
Add getEloquentQuery in queries

### DIFF
--- a/src/Concerns/HasEditRecordModal.php
+++ b/src/Concerns/HasEditRecordModal.php
@@ -4,6 +4,7 @@ namespace Mokhosh\FilamentKanban\Concerns;
 
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Illuminate\Database\Eloquent\Builder;
 
 trait HasEditRecordModal
 {
@@ -60,12 +61,12 @@ trait HasEditRecordModal
 
     protected function getEditModalRecordData(int $recordId, array $data): array
     {
-        return static::$model::find($recordId)->toArray();
+        return $this->getEloquentQuery()->find($recordId)->toArray();
     }
 
     protected function editRecord(int $recordId, array $data, array $state): void
     {
-        static::$model::find($recordId)->update($data);
+        $this->getEloquentQuery()->find($recordId)->update($data);
     }
 
     protected function getEditModalFormSchema(?int $recordId): array
@@ -93,5 +94,10 @@ trait HasEditRecordModal
     protected function getEditModalCancelButtonLabel(): string
     {
         return $this->editModalCancelButtonLabel;
+    }
+
+    protected function getEloquentQuery(): Builder
+    {
+        return static::$model::query();
     }
 }

--- a/src/Concerns/HasEditRecordModal.php
+++ b/src/Concerns/HasEditRecordModal.php
@@ -95,9 +95,4 @@ trait HasEditRecordModal
     {
         return $this->editModalCancelButtonLabel;
     }
-
-    protected function getEloquentQuery(): Builder
-    {
-        return static::$model::query();
-    }
 }

--- a/src/Concerns/HasStatusChange.php
+++ b/src/Concerns/HasStatusChange.php
@@ -19,7 +19,7 @@ trait HasStatusChange
         ]);
 
         if (method_exists(static::$model, 'setNewOrder')) {
-            $this->getEloquentQuery->setNewOrder($toOrderedIds);
+            $this->getEloquentQuery()->setNewOrder($toOrderedIds);
         }
     }
 
@@ -32,7 +32,7 @@ trait HasStatusChange
     public function onSortChanged(int $recordId, string $status, array $orderedIds): void
     {
         if (method_exists(static::$model, 'setNewOrder')) {
-            $this->getEloquentQuery->setNewOrder($orderedIds);
+            $this->getEloquentQuery()->setNewOrder($orderedIds);
         }
     }
 }

--- a/src/Concerns/HasStatusChange.php
+++ b/src/Concerns/HasStatusChange.php
@@ -14,12 +14,12 @@ trait HasStatusChange
 
     public function onStatusChanged(int $recordId, string $status, array $fromOrderedIds, array $toOrderedIds): void
     {
-        static::$model::find($recordId)->update([
+        $this->getEloquentQuery()->find($recordId)->update([
             static::$recordStatusAttribute => $status,
         ]);
 
         if (method_exists(static::$model, 'setNewOrder')) {
-            static::$model::setNewOrder($toOrderedIds);
+            $this->getEloquentQuery->setNewOrder($toOrderedIds);
         }
     }
 
@@ -32,7 +32,7 @@ trait HasStatusChange
     public function onSortChanged(int $recordId, string $status, array $orderedIds): void
     {
         if (method_exists(static::$model, 'setNewOrder')) {
-            static::$model::setNewOrder($orderedIds);
+            $this->getEloquentQuery->setNewOrder($orderedIds);
         }
     }
 }

--- a/src/Concerns/HasStatusChange.php
+++ b/src/Concerns/HasStatusChange.php
@@ -19,7 +19,7 @@ trait HasStatusChange
         ]);
 
         if (method_exists(static::$model, 'setNewOrder')) {
-            $this->getEloquentQuery()->setNewOrder($toOrderedIds);
+            static::$model::setNewOrder($toOrderedIds);
         }
     }
 
@@ -32,7 +32,7 @@ trait HasStatusChange
     public function onSortChanged(int $recordId, string $status, array $orderedIds): void
     {
         if (method_exists(static::$model, 'setNewOrder')) {
-            $this->getEloquentQuery()->setNewOrder($orderedIds);
+            static::$model::setNewOrder($orderedIds);
         }
     }
 }

--- a/src/Pages/KanbanBoard.php
+++ b/src/Pages/KanbanBoard.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Mokhosh\FilamentKanban\Concerns\HasEditRecordModal;
 use Mokhosh\FilamentKanban\Concerns\HasStatusChange;
 use UnitEnum;
+use Illuminate\Database\Eloquent\Builder;
 
 class KanbanBoard extends Page implements HasForms
 {
@@ -41,7 +42,7 @@ class KanbanBoard extends Page implements HasForms
 
     protected function records(): Collection
     {
-        return static::$model::query()
+        return $this->getEloquentQuery()
             ->when(method_exists(static::$model, 'scopeOrdered'), fn ($query) => $query->ordered())
             ->get();
     }
@@ -70,5 +71,10 @@ class KanbanBoard extends Page implements HasForms
             : $status['id'];
 
         return $records->where(static::$recordStatusAttribute, $filter)->all();
+    }
+
+    protected function getEloquentQuery(): Builder
+    {
+        return static::$model::query();
     }
 }


### PR DESCRIPTION
I'm sending this pull request because I believe we failed to declare getEloquentQuery in the classes, as we generally want to reuse the same queries over and over again. And repeating it over and over is kind of boring.

I defaulted to Filament to use the same function used in its other features.

I'll be here if you need further explanation