### PR TITLE
Allow custom stub file to be used for board.

### DIFF
--- a/src/Commands/MakeKanbanBoardCommand.php
+++ b/src/Commands/MakeKanbanBoardCommand.php
@@ -14,7 +14,11 @@ class MakeKanbanBoardCommand extends GeneratorCommand
 
     protected function getStub()
     {
-        return __DIR__ . '/../../stubs/board.stub';
+         $stub="board.stub";
+        
+         return file_exists($customPath = $this->laravel->basePath("/stubs/filament-kanban/" . trim($stub, '/')))
+            ? $customPath
+            : __DIR__."/../../stubs/$stub";
     }
 
     protected function getDefaultNamespace($rootNamespace)


### PR DESCRIPTION
allow custom stub file for board.

the custom path will be in `/stubs/filament-kanban/board.stub`.   if custom file  not found then we use the default one.