### PR TITLE
Allow custom stub file to be used for board.

### DIFF
--- a/src/Commands/MakeKanbanBoardCommand.php
+++ b/src/Commands/MakeKanbanBoardCommand.php
@@ -14,11 +14,13 @@ class MakeKanbanBoardCommand extends GeneratorCommand
 
     protected function getStub()
     {
-        return __DIR__ . '/../../stubs/board.stub';
+        return file_exists($customPath = $this->laravel->basePath('/stubs/filament-kanban/board.stub'))
+            ? $customPath
+            : __DIR__.'/../../stubs/board.stub';
     }
 
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Filament\Pages';
+        return $rootNamespace.'\Filament\Pages';
     }
 }

--- a/tests/Tests/KanbanBoardTest.php
+++ b/tests/Tests/KanbanBoardTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\File;
 use Mokhosh\FilamentKanban\Tests\Enums\TaskStatus;
 use Mokhosh\FilamentKanban\Tests\Models\Task;
 use Mokhosh\FilamentKanban\Tests\Pages\TestBoard;
@@ -9,6 +10,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 it('can make kanban board from the stub', function () {
+    File::delete($this->app->basePath('app/Filament/Pages/TestBoard.php'));
     $pagesPath = $this->app->basePath('app/Filament/Pages');
 
     $this->artisan('make:kanban TestBoard')->assertExitCode(0);

--- a/tests/Tests/KanbanBoardTest.php
+++ b/tests/Tests/KanbanBoardTest.php
@@ -20,6 +20,21 @@ it('can make kanban board from the stub', function () {
         ->toContainAsFile('class TestBoard extends KanbanBoard');
 });
 
+it('can make kanban board from custom stub', function () {
+    File::delete($this->app->basePath('app/Filament/Pages/TestBoard.php'));
+    File::delete($this->app->basePath('stubs/filament-kanban/board.stub'));
+    File::ensureDirectoryExists($this->app->basePath('/stubs/filament-kanban/'));
+    File::put($this->app->basePath('/stubs/filament-kanban/board.stub'), 'custom stub');
+
+    $pagesPath = $this->app->basePath('app/Filament/Pages');
+
+    $this->artisan('make:kanban TestBoard')->assertExitCode(0);
+
+    expect($pagesPath . '/TestBoard.php')
+        ->toBeFile()
+        ->toContainAsFile('custom stub');
+});
+
 it('loads statuses', function () {
     $statuses = TaskStatus::statuses()
         ->pluck('title')


### PR DESCRIPTION
Hi, 

i have done the requested changes, hopefully everything is correct now.

- [x] Make sure to fix the styling. You can run pint for this.
- [x] Get rid of the $stub variable and inline it
- [x] Get rid of the trim function since this method is not dynamic.