### PR TITLE
Add --force flag to allow the user to regenerate board file if it already exists

### DIFF
--- a/src/Commands/MakeKanbanBoardCommand.php
+++ b/src/Commands/MakeKanbanBoardCommand.php
@@ -6,11 +6,11 @@ use Illuminate\Console\GeneratorCommand;
 
 class MakeKanbanBoardCommand extends GeneratorCommand
 {
-    public $name = 'make:kanban';
-
     public $description = 'Create a filament kanban board page';
 
     public $type = 'Kanban page';
+
+    protected $signature = 'make:kanban {name} {--force : Force kanban board to recreated}';
 
     protected function getStub()
     {

--- a/src/Commands/MakeKanbanBoardCommand.php
+++ b/src/Commands/MakeKanbanBoardCommand.php
@@ -6,11 +6,11 @@ use Illuminate\Console\GeneratorCommand;
 
 class MakeKanbanBoardCommand extends GeneratorCommand
 {
+    protected $signature = 'make:kanban {name} {--force : Force kanban board to recreated}';
+
     public $description = 'Create a filament kanban board page';
 
     public $type = 'Kanban page';
-
-    protected $signature = 'make:kanban {name} {--force : Force kanban board to recreated}';
 
     protected function getStub()
     {

--- a/tests/Tests/KanbanBoardTest.php
+++ b/tests/Tests/KanbanBoardTest.php
@@ -35,6 +35,36 @@ it('can make kanban board from custom stub', function () {
         ->toContainAsFile('custom stub');
 });
 
+it('can make force recreate kanban board ', function () {
+    File::delete($this->app->basePath('app/Filament/Pages/TestBoard.php'));
+    File::delete($this->app->basePath('stubs/filament-kanban/board.stub'));
+    $pagesPath = $this->app->basePath('app/Filament/Pages');
+
+    $this->artisan('make:kanban TestBoard')->assertExitCode(0);
+
+    expect($pagesPath . '/TestBoard.php')
+        ->toBeFile()
+        ->toContainAsFile('class TestBoard extends KanbanBoard');
+
+    File::ensureDirectoryExists($this->app->basePath('/stubs/filament-kanban/'));
+    File::put($this->app->basePath('/stubs/filament-kanban/board.stub'), 'custom stub');
+
+    $this->artisan('make:kanban TestBoard')->assertExitCode(0);
+
+    expect($pagesPath . '/TestBoard.php')
+        ->toBeFile()
+        ->not->toContainAsFile('custom stub');
+
+    $this->artisan('make:kanban', [
+        'name' => 'TestBoard',
+        '--force' => true,
+    ])->assertExitCode(0);
+
+    expect($pagesPath . '/TestBoard.php')
+        ->toBeFile()
+        ->toContainAsFile('custom stub');
+});
+
 it('loads statuses', function () {
     $statuses = TaskStatus::statuses()
         ->pluck('title')


### PR DESCRIPTION
Hi,

i believe this is what you have requested.

 Instead of removing the kanban board file then run the command again, user can add --force and voila!