### PR TITLE
Add new command to generate board page for a specific Filament resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ php artisan filament-kanban:install
 
 ## Before You Start
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > You should have some `Model` with a `status` column. This column can be called `status` in the database or anything else.
 
 I'm also assuming there's a `title` column on your model, but you can have `name` or any other column to represent a title.
@@ -62,6 +62,9 @@ You can create a new Kanban board called `UsersKanbanBoard` using this artisan c
 
 ```php
 php artisan make:kanban UsersKanbanBoard
+
+# or, if the board is for a specific resource
+php artisan make:resource-kanban UsersKanbanBoard UserResource
 ```
 
 This creates a good starting point for your Kanban board. You can customize the Kanban board to your liking.
@@ -76,6 +79,24 @@ You should also override the `statusEnum` property, which defines your statuses.
 
 ```php
 protected static string $statusEnum = UserStatus::class;
+```
+
+If you made a board for a specific resource, you should also override the `$resource` property:
+
+```php
+protected static string $resource = Resource::class;
+```
+
+Then, don't forget to register the page inside your Filament resource :
+
+```php
+public static function getPages(): array
+{
+    return [
+        'index' => Pages\ManageUsers::route('/'),
+        'kanban' => Pages\UsersKanbanBoard::route('/kanban'),
+    ];
+}
 ```
 
 ## Upgrade Guide
@@ -270,7 +291,7 @@ Are you a visual learner? I have created some Youtube videos to get you started 
 > [!WARNING]
 > These videos are recorded with version 1.x of the package.
 > It is now much simpler to use the package, and requires much less code from you.
-> 
+>
 > Hopefully, version 2.x is simple enough to not require videos, but you can still learn a thing or two from these.
 
 [![Creating a Kanban Board in FilamentPHP using filament-kanban: Part 1, Basic setup](https://i3.ytimg.com/vi/GquNTj50E78/maxresdefault.jpg)](https://www.youtube.com/watch?v=GquNTj50E78)

--- a/src/Commands/MakeKanbanResourceBoardCommand.php
+++ b/src/Commands/MakeKanbanResourceBoardCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Mokhosh\FilamentKanban\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MakeKanbanResourceBoardCommand extends GeneratorCommand
+{
+    public $name = 'make:resource-kanban';
+
+    public $description = 'Create a filament kanban board page for a resource';
+
+    public $type = 'Kanban page';
+
+    protected function getStub()
+    {
+        return __DIR__ . '/../../stubs/resource-board.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Filament\Resources\\'. $this->getResourceInput() .'\Pages';
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getResourceInput()
+    {
+        return ucfirst(Str::camel(trim($this->argument('resource'))));
+    }
+
+    protected function getArguments()
+    {
+        return array_merge(parent::getArguments(), [
+            ['resource', InputArgument::REQUIRED, 'The name of the resource to create the page in'],
+        ]);
+    }
+}

--- a/src/Concerns/HasKanbanPage.php
+++ b/src/Concerns/HasKanbanPage.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Mokhosh\FilamentKanban\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Mokhosh\FilamentKanban\Concerns\HasEditRecordModal;
+use Mokhosh\FilamentKanban\Concerns\HasStatusChange;
+
+trait HasKanbanPage
+{
+    use HasEditRecordModal;
+    use HasStatusChange;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static string $view = 'filament-kanban::kanban-board';
+
+    protected static string $headerView = 'filament-kanban::kanban-header';
+
+    protected static string $recordView = 'filament-kanban::kanban-record';
+
+    protected static string $statusView = 'filament-kanban::kanban-status';
+
+    protected static string $scriptsView = 'filament-kanban::kanban-scripts';
+
+    protected static string $recordTitleAttribute = 'title';
+
+    protected static string $recordStatusAttribute = 'status';
+
+    protected function statuses(): Collection
+    {
+        return static::$statusEnum::statuses();
+    }
+
+    protected function records(): Collection
+    {
+        return $this->getEloquentQuery()
+            ->when(method_exists(static::$model, 'scopeOrdered'), fn ($query) => $query->ordered())
+            ->get();
+    }
+
+    protected function getViewData(): array
+    {
+        $records = $this->records();
+        $statuses = $this->statuses()
+            ->map(function ($status) use ($records) {
+                $status['records'] = $this->filterRecordsByStatus($records, $status);
+
+                return $status;
+            });
+
+        return [
+            'statuses' => $statuses,
+        ];
+    }
+
+    protected function filterRecordsByStatus(Collection $records, array $status): array
+    {
+        $statusIsCastToEnum = $records->first()?->getAttribute(static::$recordStatusAttribute) instanceof UnitEnum;
+
+        $filter = $statusIsCastToEnum
+            ? static::$statusEnum::from($status['id'])
+            : $status['id'];
+
+        return $records->where(static::$recordStatusAttribute, $filter)->all();
+    }
+
+    protected function getEloquentQuery(): Builder
+    {
+        return static::$model::query();
+    }
+}

--- a/src/FilamentKanbanServiceProvider.php
+++ b/src/FilamentKanbanServiceProvider.php
@@ -2,16 +2,17 @@
 
 namespace Mokhosh\FilamentKanban;
 
-use Filament\Support\Assets\Asset;
 use Filament\Support\Assets\Css;
-use Filament\Support\Facades\FilamentAsset;
+use Filament\Support\Assets\Asset;
 use Illuminate\Filesystem\Filesystem;
+use Spatie\LaravelPackageTools\Package;
+use Filament\Support\Facades\FilamentAsset;
 use Livewire\Features\SupportTesting\Testable;
-use Mokhosh\FilamentKanban\Commands\MakeKanbanBoardCommand;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Mokhosh\FilamentKanban\Testing\TestsFilamentKanban;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Mokhosh\FilamentKanban\Commands;
+use Mokhosh\FilamentKanban\Commands;
 
 class FilamentKanbanServiceProvider extends PackageServiceProvider
 {
@@ -79,7 +80,8 @@ class FilamentKanbanServiceProvider extends PackageServiceProvider
     protected function getCommands(): array
     {
         return [
-            MakeKanbanBoardCommand::class,
+            Commands\MakeKanbanBoardCommand::class,
+            Commands\MakeKanbanResourceBoardCommand::class,
         ];
     }
 }

--- a/src/Pages/KanbanBoard.php
+++ b/src/Pages/KanbanBoard.php
@@ -3,77 +3,13 @@
 namespace Mokhosh\FilamentKanban\Pages;
 
 use Filament\Pages\Page;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
-use Mokhosh\FilamentKanban\Concerns\HasEditRecordModal;
-use Mokhosh\FilamentKanban\Concerns\HasStatusChange;
-use UnitEnum;
+use Mokhosh\FilamentKanban\Concerns\HasKanbanPage;
 
 class KanbanBoard extends Page
 {
-    use HasEditRecordModal;
-    use HasStatusChange;
-
-    protected static ?string $navigationIcon = 'heroicon-o-document-text';
-
-    protected static string $view = 'filament-kanban::kanban-board';
-
-    protected static string $headerView = 'filament-kanban::kanban-header';
-
-    protected static string $recordView = 'filament-kanban::kanban-record';
-
-    protected static string $statusView = 'filament-kanban::kanban-status';
-
-    protected static string $scriptsView = 'filament-kanban::kanban-scripts';
+    use HasKanbanPage;
 
     protected static string $model;
 
     protected static string $statusEnum;
-
-    protected static string $recordTitleAttribute = 'title';
-
-    protected static string $recordStatusAttribute = 'status';
-
-    protected function statuses(): Collection
-    {
-        return static::$statusEnum::statuses();
-    }
-
-    protected function records(): Collection
-    {
-        return $this->getEloquentQuery()
-            ->when(method_exists(static::$model, 'scopeOrdered'), fn ($query) => $query->ordered())
-            ->get();
-    }
-
-    protected function getViewData(): array
-    {
-        $records = $this->records();
-        $statuses = $this->statuses()
-            ->map(function ($status) use ($records) {
-                $status['records'] = $this->filterRecordsByStatus($records, $status);
-
-                return $status;
-            });
-
-        return [
-            'statuses' => $statuses,
-        ];
-    }
-
-    protected function filterRecordsByStatus(Collection $records, array $status): array
-    {
-        $statusIsCastToEnum = $records->first()?->getAttribute(static::$recordStatusAttribute) instanceof UnitEnum;
-
-        $filter = $statusIsCastToEnum
-            ? static::$statusEnum::from($status['id'])
-            : $status['id'];
-
-        return $records->where(static::$recordStatusAttribute, $filter)->all();
-    }
-
-    protected function getEloquentQuery(): Builder
-    {
-        return static::$model::query();
-    }
 }

--- a/src/Resources/Pages/KanbanBoard.php
+++ b/src/Resources/Pages/KanbanBoard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mokhosh\FilamentKanban\Resources\Pages;
+
+use UnitEnum;
+use Filament\Resources\Pages\Page;
+use Mokhosh\FilamentKanban\Concerns\HasKanbanPage;
+
+abstract class KanbanBoard extends Page
+{
+    use HasKanbanPage;
+
+    protected static string $model;
+
+    protected static string $statusEnum;
+
+    protected static string $resource;
+}

--- a/stubs/resource-board.stub
+++ b/stubs/resource-board.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace DummyNamespace;
+
+use Mokhosh\FilamentKanban\Resources\Pages\KanbanBoard;
+
+class DummyClass extends KanbanBoard
+{
+    protected static string $model = Model::class;
+
+    protected static string $statusEnum = ModelStatus::class;
+
+    protected static string $resource = Resource::class;
+}


### PR DESCRIPTION
- Adapted the KanbanBoard class so one can extend the `Filament\Resources\Pages\Page` instead of `Filament\Pages\Page`
- Added a command and a stub to use this now class instead of the default page class